### PR TITLE
Add workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: CD
+
+on:
+  push:
+    branches:    
+      - master 
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn install -DskipTests
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: target
+          path: target
+
+  dockerize:
+    if: success() && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: target
+      - name: Set env
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
+      - name: Build the Docker image
+        run: docker build -t vaibhawj/hygieia-gitlab-scm:${{ env.RELEASE_VERSION }} .
+      - name: Login to docker repo
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish the Docker image
+        run: docker push vaibhawj/hygieia-gitlab-scm:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Added workflow to do a maven build on every push on master. Tests are being skipped as there are some failures.
If a tag (e.g. v0.0.2 ) is pushed, it will trigger docker build and push the image to https://hub.docker.com/r/vaibhawj/hygieia-gitlab-scm